### PR TITLE
[Working Fireplace] Converted to Harmony patch for Android compatibility

### DIFF
--- a/WorkingFireplace_Project/WorkingFireplace/WorkingFireplace.csproj
+++ b/WorkingFireplace_Project/WorkingFireplace/WorkingFireplace.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -7,7 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>WorkingFireplace</RootNamespace>
     <AssemblyName>WorkingFireplace</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WorkingFireplace_Project/WorkingFireplace/manifest.json
+++ b/WorkingFireplace_Project/WorkingFireplace/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "WorkingFireplace",
   "Author": "jahangmar",
-  "Version": "1.5.1",
+  "Version": "1.5.2",
   "Description": "The fireplace consumes wood and sleeping in your cold house drains energy",
   "UniqueID": "jahangmar.WorkingFireplace",
   "MinimumApiVersion": "3.0.0",

--- a/WorkingFireplace_Project/changelog
+++ b/WorkingFireplace_Project/changelog
@@ -7,6 +7,9 @@
 	-added configuration option (true by default) that lights the
 	fireplace in the first night on the farm
 
+1.5.2:
+	-updated for Android compatibility (thanks to Logofe)
+
 next:
 	-updated Italian translation (thanks to S-zombie)
 	-added Korean translation (thanks to overwritten)


### PR DESCRIPTION
Hello! The previous version did not work on Android devices due to input differences (no ability for IsUseToolButton and IsActionButton checks). Instead of relying on Input.ButtonPressed events, I've rewritten this code as a Harmony patch to intervene directly at Furniture.checkForAction.

I have tested the new code on Android and PC. The only change in previous behavior is that fireplaces can no longer be turned off in the usual way (this is to avoid accidental clicks on Android). You can still turn a fireplace off at any time by moving it (left-click).